### PR TITLE
Add UI for inactive projects

### DIFF
--- a/serviceweb/forms/__init__.py
+++ b/serviceweb/forms/__init__.py
@@ -168,6 +168,7 @@ _DESC = 'To delete entries, uncheck them and submit the form.'
 
 class NewProjectForm(BaseForm):
     name = fields.StringField()
+    active = fields.BooleanField()
     homepage = fields.StringField()
     description = fields.TextAreaField()
     long_description = LargeTextAreaField(description='You can use Markdown.')

--- a/serviceweb/templates/home.html
+++ b/serviceweb/templates/home.html
@@ -27,6 +27,10 @@
 {% for project in search_results %}
 <div>
   <a href="/project/{{project.id}}">{{project.name}}</a>
+  {% if not project.active %}
+  <span class="glyphicon glyphicon-alert" aria-hidden="true"
+        title="Project is not currently active"></span>
+  {% endif %}
 </div>
 {% endfor %}
 

--- a/serviceweb/templates/info.html
+++ b/serviceweb/templates/info.html
@@ -23,6 +23,10 @@
           <span class="glyphicon glyphicon-eye-close" aria-hidden="true"></span>
           {% endif %}
           <a href="/project/{{project.id}}">{{project.name}}</a>
+          {% if not project.active %}
+          <span class="glyphicon glyphicon-alert" aria-hidden="true"
+                title="Project is not currently active"></span>
+          {% endif %}
         </td>
         <td>
           {% if project.qa_primary_id %}

--- a/serviceweb/templates/project.html
+++ b/serviceweb/templates/project.html
@@ -5,6 +5,13 @@
 
 {% block page %}
 
+{% if not project.active %}
+<div class="alert alert-warning" role="alert">
+  <span class="glyphicon glyphicon-alert" aria-hidden="true"></span>
+  Project is not currently active
+</div>
+{% endif %}
+
 <h3>
 {% for tag in project.tags %}
 <a class="label label-success" href="/?search={{tag.name}}">{{tag.name}}</a>
@@ -179,6 +186,4 @@
       $('.nailthumb-container').nailthumb({width:100,height:100});
     });
 </script>
-  {% endblock %} 
-
-
+  {% endblock %}


### PR DESCRIPTION
Adds a simple UI hint for inactive projects. See https://github.com/mozilla/servicebook/issues/36 for details and screenshots. /cc @rbillings @karlht 