### PR TITLE
Fix path to static font files

### DIFF
--- a/serviceweb/server.py
+++ b/serviceweb/server.py
@@ -27,7 +27,7 @@ import humanize
 
 HERE = os.path.dirname(__file__)
 DEFAULT_INI_FILE = os.path.join(HERE, '..', 'serviceweb.ini')
-_FONTS = os.path.join(HERE, 'fonts')
+_FONTS = os.path.abspath(os.path.join(HERE, 'fonts'))
 _DEBUG = os.environ.get('FLASK_ENV') == 'development'
 sentry = Sentry()
 


### PR DESCRIPTION
`_FONTS` was including the directory name serviceweb, which meant the font files could not be found. Fixes #191